### PR TITLE
MidiALSA: Fix crash when snd_seq_subscribe_port fails

### DIFF
--- a/midi/MidiALSA.h
+++ b/midi/MidiALSA.h
@@ -80,6 +80,7 @@ protected:
     snd_rawmidi_t* handle;
     pthread_mutex_t lock;
     pthread_t thread;
+    bool have_thread;
     CMidiInHW(snd_seq_t* seq, int client, int port, const char_type* n, void* p);
     ~CMidiInHW();
     virtual void ReadMidiInput(void*,std::vector<unsigned char>&);


### PR DESCRIPTION
The pthread and lock are never created if the "if" in the constructor
fails, and the members are never initialized.  But the destructor
unconditionally destroys them.  Fix this by adding a guard flag.

This fixes a segfault I encountered on Arch with Pipewire as the ALSA
server.

    Thread 1 "node" received signal SIGSEGV, Segmentation fault.
    0x00007ffff428aebd in pthread_cancel () from /usr/bin/../lib/libc.so.6
    (gdb) bt
    #0  0x00007ffff428aebd in pthread_cancel () from /usr/bin/../lib/libc.so.6
    #1  0x00007ffff3b773ff in CMidiInHW::~CMidiInHW (this=0x55555572a430, __in_chrg=<optimized out>) at ../../midi/MidiALSA.cpp:366
    #2  0x00007ffff3b77452 in CMidiInHW::~CMidiInHW (this=0x55555572a430, __in_chrg=<optimized out>) at ../../midi/MidiALSA.cpp:369
    #3  0x00007ffff3b77105 in CMidiALSA::MidiInOpen[abi:cxx11](wchar_t const*, void*) (this=0x5555557b9880, name=0x5555556b3cf0 L"input", p=0x55555579e3a0) at ../../midi/MidiALSA.cpp:329
    #4  0x00007ffff3b6f0c8 in MidiInOpen (env=0x55555579e410, args=0x7fffffff9e20) at ../jazz-midi.cpp:461
    #5  0x00007ffff535bd33 in ?? () from /usr/bin/../lib/libnode.so.115
    #6  0x00007ffff5840d97 in ?? () from /usr/bin/../lib/libnode.so.115
    #7  0x00007ffff5841942 in v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) () from /usr/bin/../lib/libnode.so.115
    #8  0x00007ffff56cadf6 in ?? () from /usr/bin/../lib/libnode.so.115
