### PR TITLE
fix: devices not updating when running in node.js

### DIFF
--- a/midi/MidiMacOSX.cpp
+++ b/midi/MidiMacOSX.cpp
@@ -1,5 +1,6 @@
 #include <Carbon/Carbon.h>
 #include <CoreAudio/CoreAudio.h>
+#include <CoreMIDI/CoreMIDI.h>
 #include <AudioToolbox/AudioToolbox.h>
 #include <sys/time.h>
 #include <sstream>
@@ -127,7 +128,7 @@ std::vector<str_type> CMidiMacOSX::MidiOutList()
     CFStringRef S;
     std::vector<str_type> v;
     v.push_back(fromUtf8(DefaultOut));
-    //CFRunLoopRef ref = CFRunLoopGetCurrent();
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
     ItemCount k = MIDIGetNumberOfDestinations();
     for (ItemCount i = 0; i < k; ++i) {
         MIDIEndpointRef device = MIDIGetDestination(i);
@@ -185,6 +186,7 @@ std::vector<str_type> CMidiMacOSX::MidiOutInfo(int n)
 {
     if (!n) return GetDefaultInfo();
     n--;
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
     MIDIEndpointRef device = MIDIGetDestination(n);
     if (device) return GetInfo(device);
     return std::vector<str_type>();
@@ -194,6 +196,7 @@ std::vector<str_type> CMidiMacOSX::MidiOutInfo(int n)
 std::vector<str_type> CMidiMacOSX::MidiOutInfo(const char_type* name)
 {
     if (fromUtf8(DefaultOut) == name) return GetDefaultInfo();
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
     ItemCount k = MIDIGetNumberOfDestinations();
     CFStringRef S;
     for (size_t i = 0; i < k; ++i) {
@@ -207,6 +210,7 @@ std::vector<str_type> CMidiMacOSX::MidiOutInfo(const char_type* name)
 
 std::vector<str_type> CMidiMacOSX::MidiInInfo(int n)
 {
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
     MIDIEndpointRef device = MIDIGetSource(n);
     if (device) return GetInfo(device);
     return std::vector<str_type>();
@@ -215,6 +219,7 @@ std::vector<str_type> CMidiMacOSX::MidiInInfo(int n)
 
 std::vector<str_type> CMidiMacOSX::MidiInInfo(const char_type* name)
 {
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
     ItemCount k = MIDIGetNumberOfSources();
     CFStringRef S;
     for (size_t i = 0; i < k; ++i) {
@@ -228,7 +233,8 @@ std::vector<str_type> CMidiMacOSX::MidiInInfo(const char_type* name)
 
 str_type CMidiMacOSX::MidiOutOpen(int n)
 {
-    if (n < 0 || n > MIDIGetNumberOfDestinations()) return CurrentOutName();
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
+    if (n < 0 || static_cast<ItemCount>(n) > MIDIGetNumberOfDestinations()) return CurrentOutName();
     if (!n) {
         SetOut(new CMidiOutSW());
         return CurrentOutName();
@@ -249,6 +255,7 @@ str_type CMidiMacOSX::MidiOutOpen(int n)
 
 str_type CMidiMacOSX::MidiOutOpen(const char_type* name)
 {
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
     if (CurrentOutName() == name) return CurrentOutName();
     if (fromUtf8(DefaultOut) == name) {
         SetOut(new CMidiOutSW());
@@ -306,7 +313,8 @@ void CMidiInHW::ReadMidiInput(void* data, std::vector<unsigned char>& v)
 
 str_type CMidiMacOSX::MidiInOpen(int n, void* p)
 {
-    if (n < 0 || n >= MIDIGetNumberOfSources()) return CurrentInName();
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
+    if (n < 0 || static_cast<ItemCount>(n) >= MIDIGetNumberOfSources()) return CurrentInName();
     CFStringRef S;
     MIDIPortRef port;
     MIDIEndpointRef src=MIDIGetSource(n);
@@ -322,6 +330,7 @@ str_type CMidiMacOSX::MidiInOpen(int n, void* p)
 
 str_type CMidiMacOSX::MidiInOpen(const char_type* name, void* p)
 {
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
     if (CurrentInName() == name) return CurrentInName();
     CFStringRef S;
     MIDIPortRef port;
@@ -352,7 +361,6 @@ struct ThreadParam
 
 void* ThreadWrapper(void* p)
 {
-    //CFRunLoopRef ref = CFRunLoopGetCurrent();
     ThreadParam* tp = (ThreadParam*)p; tp->func(tp->ptr); delete tp; return 0;
 }
 


### PR DESCRIPTION
fixes #8 

When running in node there is no CFRunLoop to drive CoreMIDI internal updates.
see: https://developer.apple.com/documentation/corefoundation/cfrunloop

There are two ways to address the issue.
  1. start the loop in a separate thread when needed
  2. drive the loop manually with CFRunLoop

This implementation is **2.** It's a brute force and probably has some minor performance impact since we yield to the loop on each call to Midi*Info Midi*List and a few other places. It would probably be far better to spawn a thread but I'm not a very strong C++ developer and my skills with low level threading are super rusty. It looks like some code was started to enable this external threading. I'm hoping the brute force approach is acceptable as a bug fix, until someone with more experience in native module development and OSX is able to do something better or I find some time to bang on this again.